### PR TITLE
TF destroy fix

### DIFF
--- a/mission_21/terraform/gke.tf
+++ b/mission_21/terraform/gke.tf
@@ -42,11 +42,7 @@ resource "kubernetes_namespace" "lbg-trainer" {
   metadata {
     name = "lbg-trainer"
   }
-
-  provisioner "local-exec" {
-    when = destroy
-    command = "nohup ${path.module}/namespace-finalizer.sh lbg-trainer 2>&1 &"
-  }
+  depends_on = [ google_container_node_pool.primary_nodes ]
 }
 
 resource "kubernetes_namespace" "lbg" {
@@ -54,9 +50,5 @@ resource "kubernetes_namespace" "lbg" {
   metadata {
     name = "lbg-${count.index + 1}"
   }
-
-  provisioner "local-exec" {
-    when = destroy
-    command = "nohup ${path.module}/namespace-finalizer.sh lbg-${count.index + 1} 2>&1 &"
-  }
+  depends_on = [ google_container_node_pool.primary_nodes ]
 }

--- a/mission_21/terraform/gke.tf
+++ b/mission_21/terraform/gke.tf
@@ -42,11 +42,21 @@ resource "kubernetes_namespace" "lbg-trainer" {
   metadata {
     name = "lbg-trainer"
   }
+
+  provisioner "local-exec" {
+    when = destroy
+    command = "nohup ${path.module}/namespace-finalizer.sh lbg-trainer 2>&1 &"
+  }
 }
 
 resource "kubernetes_namespace" "lbg" {
   count = var.delegatecount 
   metadata {
     name = "lbg-${count.index + 1}"
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+    command = "nohup ${path.module}/namespace-finalizer.sh lbg-${count.index + 1} 2>&1 &"
   }
 }

--- a/mission_21/terraform/namespace-finalizer.sh
+++ b/mission_21/terraform/namespace-finalizer.sh
@@ -1,0 +1,1 @@
+sleep 30; kubectl get ns $1 && kubectl get ns $1 -o json | jq 'del(.spec.finalizers[0])' | kubectl replace --raw "/api/v1/namespaces/$1/finalize" -f -

--- a/mission_21/terraform/namespace-finalizer.sh
+++ b/mission_21/terraform/namespace-finalizer.sh
@@ -1,1 +1,0 @@
-sleep 30; kubectl get ns $1 && kubectl get ns $1 -o json | jq 'del(.spec.finalizers[0])' | kubectl replace --raw "/api/v1/namespaces/$1/finalize" -f -


### PR DESCRIPTION
K8s namespaces now depend on node pool - previously deleting the node pool terminated resources which were required by the namespaces' finalizers